### PR TITLE
Require Cable.Channel constructors to define their channel name

### DIFF
--- a/lib/assets/javascripts/channel.js.coffee
+++ b/lib/assets/javascripts/channel.js.coffee
@@ -1,9 +1,12 @@
 class @Cable.Channel
   constructor: (params = {}) ->
-    @channelName ?= "#{@underscore(@constructor.name)}_channel"
+    {channelName} = @constructor
 
-    params['channel'] = @channelName
-    @channelIdentifier = JSON.stringify params
+    if channelName?
+      params['channel'] = channelName
+      @channelIdentifier = JSON.stringify params
+    else
+      throw new Error "This channel's constructor is missing the required 'channelName' property"
 
     cable.subscribe(@channelIdentifier, {
       onConnect: @connected
@@ -28,7 +31,3 @@ class @Cable.Channel
 
   send: (data) ->
     cable.sendData @channelIdentifier, JSON.stringify data
-
-
-  underscore: (value) ->
-    value.replace(/[A-Z]/g, (match) => "_#{match.toLowerCase()}").substr(1)


### PR DESCRIPTION
`Function.name` is not currently supported in Internet Explorer so it can't be used reliably to infer the channel name. See [Browser compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name#Browser_compatibility).

Even if it were supported, function names may be altered if processed by a minifier like [Uglifier](https://github.com/lautis/uglifier), which in turn would alter the inferred channel name. See [this blog post](http://www.wulftone.com/2013/08/07/uglifier-changes-constructor-names/) and https://github.com/jashkenas/coffeescript/issues/2052.
