### PR TITLE
ActionCable.server should always return the same instance

### DIFF
--- a/lib/action_cable.rb
+++ b/lib/action_cable.rb
@@ -28,6 +28,6 @@ module ActionCable
 
   # Singleton instance of the server
   module_function def server
-    ActionCable::Server::Base.new
+    @server ||= ActionCable::Server::Base.new
   end
 end


### PR DESCRIPTION
`ActionCable.server` should always return the same instance, not a fresh one on each access.