### PR TITLE
Freshen Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,18 @@
 PATH
   remote: .
   specs:
-    action_cable (0.1.0)
+    actioncable (0.1.0)
       activesupport (>= 4.2.0)
       celluloid (~> 0.16.0)
       em-hiredis (~> 0.3.0)
       faye-websocket (~> 0.9.2)
       redis (~> 3.0)
+      websocket-driver (= 0.5.4)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (4.2.2)
+    activesupport (4.2.3)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -49,7 +50,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  action_cable!
+  actioncable!
   puma
   rake
 


### PR DESCRIPTION
Freshen the Gemfile.lock. Generated from a fresh `bundle install`.

- Adds missing dependency for `websocket-driver`
- Updates `activesupport`
- Updates the gem name: `action_cable` -> `actioncable`