### PR TITLE
update documentation to use websocket protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ The client-side needs to setup a consumer instance of this connection. That's do
 ```coffeescript
 # app/assets/javascripts/cable.coffee
 @App = {}
-App.cable = Cable.createConsumer "http://cable.example.com"
+App.cable = Cable.createConsumer "ws://cable.example.com"
 ```
 
-The http://cable.example.com address must point to your set of Action Cable servers, and it
+The ws://cable.example.com address must point to your set of Action Cable servers, and it
 must share a cookie namespace with the rest of the application (which may live under http://example.com).
 This ensures that the signed cookie will be correctly sent.
 
@@ -249,7 +249,7 @@ bundle exec puma -p 28080  cable/config.ru
 ```
 
 That'll start a cable server on port 28080. Remember to point your client-side setup against that using something like:
-`App.cable.createConsumer('http://basecamp.dev:28080')`.
+`App.cable.createConsumer('ws://basecamp.dev:28080')`.
 
 Note: We'll get all this abstracted properly when the framework is integrated into Rails.
 

--- a/lib/assets/javascripts/cable/consumer.js.coffee
+++ b/lib/assets/javascripts/cable/consumer.js.coffee
@@ -3,7 +3,7 @@
 #= require cable/subscriptions
 #= require cable/subscription
 
-# The Cable.Consumer establishes the connection to a server-side Ruby Connection object. Once established, 
+# The Cable.Consumer establishes the connection to a server-side Ruby Connection object. Once established,
 # the Cable.ConnectionMonitor will ensure that its properly maintained through heartbeats and checking for stale updates.
 # The Consumer instance is also the gateway to establishing subscriptions to desired channels through the #createSubscription
 # method.
@@ -11,7 +11,7 @@
 # The following example shows how this can be setup:
 #
 #   @App = {}
-#   App.cable = Cable.createConsumer "http://example.com/accounts/1"
+#   App.cable = Cable.createConsumer "ws://example.com/accounts/1"
 #   App.appearance = App.cable.subscriptions.create "AppearanceChannel"
 #
 # For more details on how you'd configure an actual channel subscription, see Cable.Subscription.

--- a/lib/assets/javascripts/cable/subscriptions.js.coffee
+++ b/lib/assets/javascripts/cable/subscriptions.js.coffee
@@ -2,7 +2,7 @@
 # us Cable.Subscriptions#create, and it should be called through the consumer like so:
 #
 #   @App = {}
-#   App.cable = Cable.createConsumer "http://example.com/accounts/1"
+#   App.cable = Cable.createConsumer "ws://example.com/accounts/1"
 #   App.appearance = App.cable.subscriptions.create "AppearanceChannel"
 #
 # For more details on how you'd configure an actual channel subscription, see Cable.Subscription.


### PR DESCRIPTION
When I try to create a consumer using http protocol, I get `Uncaught SyntaxError: Failed to construct 'WebSocket': The URL's scheme must be either 'ws' or 'wss'. 'http' is not allowed.`

This updates README and docs to use `ws` instead of `http`.