### PR TITLE
README.md code block fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ shared logic between your channels.
 
 ```ruby
 # app/channels/application_cable/channel.rb
-```ruby
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
   end


### PR DESCRIPTION
Code block had (probably accidentally) a double ruby syntax highlighting line.