### PR TITLE
Ensure ActionCable is thread-safe

### DIFF
--- a/lib/action_cable.rb
+++ b/lib/action_cable.rb
@@ -26,8 +26,7 @@ module ActionCable
   autoload :RemoteConnections, 'action_cable/remote_connections'
   autoload :Broadcaster, 'action_cable/broadcaster'
 
-  # Singleton instance of the server
   module_function def server
-    @server ||= ActionCable::Server::Base.new
+    ActionCable::Server::Base.instance
   end
 end

--- a/lib/action_cable/server/base.rb
+++ b/lib/action_cable/server/base.rb
@@ -1,3 +1,5 @@
+require 'singleton'
+
 module ActionCable
   module Server
     # A singleton ActionCable::Server instance is available via ActionCable.server. It's used by the rack process that starts the cable server, but
@@ -5,6 +7,7 @@ module ActionCable
     #
     # Also, this is the server instance used for broadcasting. See Broadcasting for details.
     class Base
+      include Singleton
       include ActionCable::Server::Broadcasting
       include ActionCable::Server::Connections
 


### PR DESCRIPTION
Although this is unlikely to cause any problems specially because this
is first run as "run ActionCable.server" and it's very unlikely to call
multiple rack "run" methods concurrently and even if we did so it's not
guaranteed that would cause any troubles, it's much better not having to
worry about this and just ensuring this is thread-safe.

It might seem that @a ||= A.new pattern runs atomically, but this is not
guaranteed nor even by MRI. Here's an example:

```ruby
class A
  def initialize
      sleep 1
  end
  def self.instance
     @@instance ||= new
  end
end

instances = [] # I know this is not thread-safe but it demonstrates the problem anyway

(1..2).map{Thread.start{instances << A.instance}}.each &:join
instances[0] == instances[1] # false

Using the singleton pattern makes the intention clearer and worry-free.