### PR TITLE
[PoC] add rabbitmq as an adapter for actioncable

### DIFF
--- a/actioncable.gemspec
+++ b/actioncable.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'celluloid',        '~> 0.16.0'
   s.add_dependency 'em-hiredis',       '~> 0.3.0'
   s.add_dependency 'redis',            '~> 3.0'
+  s.add_dependency 'amqp'
 
   s.files = Dir['README', 'lib/**/*']
   s.has_rdoc = false

--- a/lib/action_cable/adapters/rabbitmq/broadcaster.rb
+++ b/lib/action_cable/adapters/rabbitmq/broadcaster.rb
@@ -1,0 +1,42 @@
+require 'amqp'
+
+module ActionCable
+  module Adapters
+    module RabbitMQ
+      class Broadcaster
+
+        attr_reader :config
+
+        def initialize(config)
+          @config = config
+        end
+
+        def broadcaster
+          @rabbitmq ||= BroadcastInterface.new(config.rabbitmq)
+        end
+
+        class BroadcastInterface
+
+          attr_reader :config
+
+          def initialize(config)
+            @config = config
+          end
+
+          def publish(queue, message)
+            EventMachine.run do
+              connection = AMQP.connect(config[:url])
+              channel = AMQP::Channel.new(connection)
+              exchange = channel.default_exchange
+              exchange.publish(message, routing_key: queue) do
+                connection.close { EM.stop }
+              end
+            end
+          end
+
+        end
+
+      end
+    end
+  end
+end

--- a/lib/action_cable/adapters/rabbitmq/pubsub.rb
+++ b/lib/action_cable/adapters/rabbitmq/pubsub.rb
@@ -1,0 +1,51 @@
+require 'amqp'
+
+module ActionCable
+  module Adapters
+    module RabbitMQ
+      class Pubsub
+
+        attr_reader :config
+
+        def initialize(config)
+          @config = config
+        end
+
+        # The EventMachine Redis instance used by the pubsub adapter.
+        def pubsub
+          @pubsub ||= PubsubInterface.new(config.rabbitmq)
+        end
+
+        class PubsubInterface
+
+          attr_reader :config
+
+          def initialize(config)
+            @config = config
+          end
+
+          def subscribe(channel_name, &callback)
+            EventMachine.run do
+              connection = AMQP.connect(config[:url])
+              channel = AMQP::Channel.new(connection)
+              queue = channel.queue(channel_name, :durable => true)
+              consumer = AMQP::Consumer.new(channel, queue, nil, exclusive = false, no_ack = true)
+              consumer.on_delivery do |_, message|
+                callback.call(message)
+              end
+              consumer.consume
+            end
+          end
+
+          def unsubscribe_proc(channel, callback)
+
+          end
+
+          
+
+        end
+
+      end
+    end
+  end
+end

--- a/lib/action_cable/adapters/redis/broadcaster.rb
+++ b/lib/action_cable/adapters/redis/broadcaster.rb
@@ -1,0 +1,19 @@
+module ActionCable
+  module Adapters
+    module Redis
+      class Broadcaster
+
+        attr_reader :config
+
+        def initialize(config)
+          @config = config
+        end
+
+        def broadcaster
+          @redis ||= Redis.new(config.redis)          
+        end
+
+      end
+    end
+  end
+end

--- a/lib/action_cable/adapters/redis/pubsub.rb
+++ b/lib/action_cable/adapters/redis/pubsub.rb
@@ -1,0 +1,26 @@
+module ActionCable
+  module Adapters
+    module Redis
+      class Pubsub
+
+        attr_reader :config
+
+        def initialize(config)
+          @config = config
+        end
+
+        # The EventMachine Redis instance used by the pubsub adapter.
+        def pubsub
+          @pubsub ||= EM::Hiredis.connect(config.redis[:url]).tap do |redis|
+            redis.on(:reconnect_failed) do
+              logger.info "[ActionCable] Redis reconnect failed."
+              # logger.info "[ActionCable] Redis reconnected. Closing all the open connections."
+              # @connections.map &:close
+            end            
+          end.pubsub
+        end
+
+      end
+    end
+  end
+end

--- a/lib/action_cable/server/base.rb
+++ b/lib/action_cable/server/base.rb
@@ -1,3 +1,6 @@
+require 'action_cable/adapters/redis/pubsub'
+require 'action_cable/adapters/rabbitmq/pubsub'
+
 module ActionCable
   module Server
     # A singleton ActionCable::Server instance is available via ActionCable.server. It's used by the rack process that starts the cable server, but
@@ -39,20 +42,13 @@ module ActionCable
         end
       end
 
-      # The redis pubsub adapter used for all streams/broadcasting.
-      def pubsub
-        @pubsub ||= redis.pubsub
+      def adapter
+        @adapter ||= ActionCable::Adapters::RabbitMQ::Pubsub.new(config)
       end
 
-      # The EventMachine Redis instance used by the pubsub adapter.
-      def redis
-        @redis ||= EM::Hiredis.connect(config.redis[:url]).tap do |redis|
-          redis.on(:reconnect_failed) do
-            logger.info "[ActionCable] Redis reconnect failed."
-            # logger.info "[ActionCable] Redis reconnected. Closing all the open connections."
-            # @connections.map &:close
-          end            
-        end
+      # The redis pubsub adapter used for all streams/broadcasting.
+      def pubsub
+        @pubsub ||= adapter.pubsub
       end
 
       # All the identifiers applied to the connection class associated with this server.

--- a/lib/action_cable/server/broadcasting.rb
+++ b/lib/action_cable/server/broadcasting.rb
@@ -1,3 +1,6 @@
+require 'action_cable/adapters/redis/broadcaster'
+require 'action_cable/adapters/rabbitmq/broadcaster'
+
 module ActionCable
   module Server
     # Broadcasting is how other parts of your application can send messages to the channel subscribers. As explained in Channel, most of the time, these
@@ -29,10 +32,10 @@ module ActionCable
         Broadcaster.new(self, broadcasting)
       end
 
-      # The redis instance used for broadcasting. Not intended for direct user use.
-      def broadcasting_redis
-        @broadcasting_redis ||= Redis.new(config.redis)
-      end      
+      def broadcaster
+        @broadcaster ||= ActionCable::Adapters::RabbitMQ::Broadcaster.new(config)
+        @broadcaster.broadcaster
+      end
 
       private
         class Broadcaster
@@ -44,7 +47,7 @@ module ActionCable
 
           def broadcast(message)
             server.logger.info "[ActionCable] Broadcasting to #{broadcasting}: #{message}"
-            server.broadcasting_redis.publish broadcasting, message.to_json
+            server.broadcaster.publish broadcasting, message.to_json
           end
         end
     end

--- a/lib/action_cable/server/configuration.rb
+++ b/lib/action_cable/server/configuration.rb
@@ -5,7 +5,7 @@ module ActionCable
     class Configuration
       attr_accessor :logger, :log_tags
       attr_accessor :connection_class, :worker_pool_size
-      attr_accessor :redis_path, :channels_path
+      attr_accessor :redis_path, :rabbitmq_path, :channels_path
 
       def initialize
         @logger   = Rails.logger
@@ -15,6 +15,7 @@ module ActionCable
         @worker_pool_size  = 100
 
         @redis_path    = Rails.root.join('config/redis/cable.yml')
+        @rabbitmq_path = Rails.root.join('config/rabbitmq/cable.yml')
         @channels_path = Rails.root.join('app/channels')
       end
 
@@ -30,6 +31,10 @@ module ActionCable
 
       def redis
         @redis ||= config_for(redis_path).with_indifferent_access
+      end
+
+      def rabbitmq
+        @rabbitmq ||= config_for(rabbitmq_path).with_indifferent_access
       end
 
       private


### PR DESCRIPTION
I don't want to waste your time, this is just a poc work. Maybe we can add other message brokers like ActiveMQ or Kafka or maybe we can add AWS SNS I believe we can use it for pubsub operations and also it's fully managed service so as a developer I don't need to manage the server. Or maybe somebody will create an external gem as an adapter for these but at first we need to separate Redis from source of the actioncable as an adapter like ActiveRecord's connection adapters and we need to create interface which other adapters can implement it. So what do you think about these ideas?