### PR TITLE
Server::Base broadcasting test added

### DIFF
--- a/test/server/base_test.rb
+++ b/test/server/base_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class ActionCable::Server::BaseTest < ActiveSupport::TestCase
+
+  setup do
+    mock_config
+
+    @redis = MiniTest::Mock.new
+
+    ActionCable::Server::Configuration.stub :new, @config do
+      @base = ActionCable::Server::Base.new
+    end
+  end
+
+  test "broadcast delivered to redis" do
+    @redis.expect(:publish, nil, ["test_broadcasting", "test_message".to_json])
+
+    Redis.stub :new, @redis do
+      @base.broadcast "test_broadcasting", "test_message"
+    end
+
+    @redis.verify
+  end
+
+  def mock_config
+    @config = MiniTest::Mock.new
+    @config.expect(:redis, nil)
+    def @config.logger
+      ActiveSupport::TaggedLogging.new ActiveSupport::Logger.new(StringIO.new)
+    end
+  end
+end


### PR DESCRIPTION
Hi, this is my first contribution attempt to rails community.

I created a simple test to check if a message is delivered to `Redis`, I used `Minitest::Mock` to isolate the server. Not quite sure if `ActionCable::Server::Configuration` should be mocked.

I would like to have some feedback, so I can move forward to add more tests.