### PR TITLE
Update gems and requires

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,12 +4,12 @@ PATH
     actioncable (0.1.0)
       actionpack (>= 4.2.0)
       activesupport (>= 4.2.0)
-      celluloid (~> 0.16.0)
+      celluloid (~> 0.17.0)
       coffee-rails
       em-hiredis (~> 0.3.0)
-      faye-websocket (~> 0.9.2)
+      faye-websocket (~> 0.10.0)
       redis (~> 3.0)
-      websocket-driver (= 0.5.4)
+      websocket-driver (~> 0.6.1)
 
 GEM
   remote: https://rubygems.org/
@@ -34,7 +34,46 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     builder (3.2.2)
-    celluloid (0.16.0)
+    celluloid (0.17.0)
+      bundler
+      celluloid-essentials
+      celluloid-extras
+      celluloid-fsm
+      celluloid-pool
+      celluloid-supervision
+      dotenv
+      nenv
+      rspec-logsplit (>= 0.1.2)
+      timers (~> 4.0.0)
+    celluloid-essentials (0.20.1.1)
+      bundler
+      dotenv
+      nenv
+      rspec-logsplit (>= 0.1.2)
+      timers (~> 4.0.0)
+    celluloid-extras (0.20.0)
+      bundler
+      dotenv
+      nenv
+      rspec-logsplit (>= 0.1.2)
+      timers (~> 4.0.0)
+    celluloid-fsm (0.20.0)
+      bundler
+      dotenv
+      nenv
+      rspec-logsplit (>= 0.1.2)
+      timers (~> 4.0.0)
+    celluloid-pool (0.20.0)
+      bundler
+      dotenv
+      nenv
+      rspec-logsplit (>= 0.1.2)
+      timers (~> 4.0.0)
+    celluloid-supervision (0.20.0)
+      bundler
+      dotenv
+      nenv
+      rspec-logsplit (>= 0.1.2)
       timers (~> 4.0.0)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
@@ -43,13 +82,14 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1.1)
+    dotenv (2.0.2)
     em-hiredis (0.3.0)
       eventmachine (~> 1.0)
       hiredis (~> 0.5.0)
     erubis (2.7.0)
     eventmachine (1.0.7)
     execjs (2.5.2)
-    faye-websocket (0.9.2)
+    faye-websocket (0.10.0)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     hiredis (0.5.2)
@@ -63,11 +103,11 @@ GEM
     minitest (5.7.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
+    nenv (0.2.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
-    puma (2.10.2)
-      rack (>= 1.1, < 2.0)
-    rack (1.6.0)
+    puma (2.12.2)
+    rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails-deprecated_sanitizer (1.0.3)
@@ -85,13 +125,14 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
     redis (3.2.1)
+    rspec-logsplit (0.1.3)
     thor (0.19.1)
     thread_safe (0.3.5)
     timers (4.0.1)
       hitimes
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    websocket-driver (0.5.4)
+    websocket-driver (0.6.2)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
 

--- a/actioncable.gemspec
+++ b/actioncable.gemspec
@@ -13,9 +13,9 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activesupport',    '>= 4.2.0'
   s.add_dependency 'actionpack',       '>= 4.2.0'
-  s.add_dependency 'faye-websocket',   '~> 0.9.2'
-  s.add_dependency 'websocket-driver', '= 0.5.4'
-  s.add_dependency 'celluloid',        '~> 0.16.0'
+  s.add_dependency 'faye-websocket',   '~> 0.10.0'
+  s.add_dependency 'websocket-driver', '~> 0.6.1'
+  s.add_dependency 'celluloid',        '~> 0.17.0'
   s.add_dependency 'em-hiredis',       '~> 0.3.0'
   s.add_dependency 'redis',            '~> 3.0'
   s.add_dependency 'coffee-rails'

--- a/lib/action_cable.rb
+++ b/lib/action_cable.rb
@@ -11,7 +11,7 @@ require 'active_support/core_ext/module/delegation'
 require 'active_support/callbacks'
 
 require 'faye/websocket'
-require 'celluloid'
+require 'celluloid/current'
 require 'em-hiredis'
 require 'redis'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,8 @@ Bundler.require :default, :test
 require 'puma'
 require 'mocha/mini_test'
 
+require 'rack/mock'
+
 require 'action_cable'
 ActiveSupport.test_order = :sorted
 


### PR DESCRIPTION
Use latest faye-websocket,  celluloid, and websocket-driver (now that the issue with 0.6.0 is fixed).
Require 'rack/mockt' for Rack::MockRequest used in tests