### PR TITLE
Use Celluloid 0.16.0 until termination issue in 0.17.0 is resolved

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     actioncable (0.1.0)
       actionpack (>= 4.2.0)
       activesupport (>= 4.2.0)
-      celluloid (~> 0.17.0)
+      celluloid (~> 0.16.0)
       coffee-rails
       em-hiredis (~> 0.3.0)
       faye-websocket (~> 0.10.0)
@@ -34,46 +34,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     builder (3.2.2)
-    celluloid (0.17.0)
-      bundler
-      celluloid-essentials
-      celluloid-extras
-      celluloid-fsm
-      celluloid-pool
-      celluloid-supervision
-      dotenv
-      nenv
-      rspec-logsplit (>= 0.1.2)
-      timers (~> 4.0.0)
-    celluloid-essentials (0.20.1.1)
-      bundler
-      dotenv
-      nenv
-      rspec-logsplit (>= 0.1.2)
-      timers (~> 4.0.0)
-    celluloid-extras (0.20.0)
-      bundler
-      dotenv
-      nenv
-      rspec-logsplit (>= 0.1.2)
-      timers (~> 4.0.0)
-    celluloid-fsm (0.20.0)
-      bundler
-      dotenv
-      nenv
-      rspec-logsplit (>= 0.1.2)
-      timers (~> 4.0.0)
-    celluloid-pool (0.20.0)
-      bundler
-      dotenv
-      nenv
-      rspec-logsplit (>= 0.1.2)
-      timers (~> 4.0.0)
-    celluloid-supervision (0.20.0)
-      bundler
-      dotenv
-      nenv
-      rspec-logsplit (>= 0.1.2)
+    celluloid (0.16.0)
       timers (~> 4.0.0)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
@@ -82,7 +43,6 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1.1)
-    dotenv (2.0.2)
     em-hiredis (0.3.0)
       eventmachine (~> 1.0)
       hiredis (~> 0.5.0)
@@ -103,7 +63,6 @@ GEM
     minitest (5.7.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    nenv (0.2.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     puma (2.12.2)
@@ -125,7 +84,6 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
     redis (3.2.1)
-    rspec-logsplit (0.1.3)
     thor (0.19.1)
     thread_safe (0.3.5)
     timers (4.0.1)

--- a/actioncable.gemspec
+++ b/actioncable.gemspec
@@ -15,7 +15,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'actionpack',       '>= 4.2.0'
   s.add_dependency 'faye-websocket',   '~> 0.10.0'
   s.add_dependency 'websocket-driver', '~> 0.6.1'
-  s.add_dependency 'celluloid',        '~> 0.17.0'
+  # Use 0.16.0 until https://github.com/celluloid/celluloid/issues/637 is resolved
+  s.add_dependency 'celluloid',        '~> 0.16.0'
   s.add_dependency 'em-hiredis',       '~> 0.3.0'
   s.add_dependency 'redis',            '~> 3.0'
   s.add_dependency 'coffee-rails'

--- a/lib/action_cable.rb
+++ b/lib/action_cable.rb
@@ -11,7 +11,7 @@ require 'active_support/core_ext/module/delegation'
 require 'active_support/callbacks'
 
 require 'faye/websocket'
-require 'celluloid/current'
+require 'celluloid'
 require 'em-hiredis'
 require 'redis'
 


### PR DESCRIPTION

The issue: https://github.com/celluloid/celluloid/issues/637

The issue in action:
```
Loading development environment (Rails 5.0.0.alpha)
>> exit
D, [2015-07-24T12:01:01.490817 #33479] DEBUG -- : Terminating 5 actors...
E, [2015-07-24T12:01:11.494161 #33479] ERROR -- : Couldn't cleanly terminate all actors in 10 seconds!
```

Which causes a 10 second hang before exiting.