### PR TITLE
Server::Base broadcasting test added

### DIFF
--- a/test/server/base_test.rb
+++ b/test/server/base_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class ActionCable::Server::BaseTest < ActiveSupport::TestCase
+  setup do
+    @redis = MiniTest::Mock.new
+    @base = ActionCable::Server::Base.new
+  end
+
+  test 'broadcast delivered to redis' do
+    @redis.expect(:publish, nil, ['test_broadcasting', 'test_message'.to_json])
+
+    Redis.stub :new, @redis do
+      @base.broadcast 'test_broadcasting', 'test_message'
+    end
+
+    @redis.verify
+  end
+end

--- a/test/stubs/application_cable.rb
+++ b/test/stubs/application_cable.rb
@@ -1,0 +1,4 @@
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+  end
+end

--- a/test/stubs/rails.rb
+++ b/test/stubs/rails.rb
@@ -1,0 +1,13 @@
+class Rails
+  def self.logger
+    ActiveSupport::TaggedLogging.new ActiveSupport::Logger.new(StringIO.new)
+  end
+
+  def self.root
+    Pathname.new(File.dirname(__FILE__))
+  end
+
+  def self.env
+    'TEST'
+  end
+end


### PR DESCRIPTION
Closing #30 as was being merged from my master branch instead a feature one. 

Rails and ApplicationCable are now stubbed.

I don't know what is the best way to handle config files required by the gem. As the configuration needs to load the following file `config/redis/cable.yml`.

At the moment I created an empty file under `test/config`