### PR TITLE
Optimize channel class lookup

### DIFF
--- a/lib/action_cable/connection/subscriptions.rb
+++ b/lib/action_cable/connection/subscriptions.rb
@@ -24,9 +24,7 @@ module ActionCable
         id_key = data['identifier']
         id_options = ActiveSupport::JSON.decode(id_key).with_indifferent_access
 
-        subscription_klass = connection.server.channel_classes.detect do |channel_class|
-          channel_class == id_options[:channel].safe_constantize
-        end
+        subscription_klass = connection.server.channel_classes[id_options[:channel]]
 
         if subscription_klass
           subscriptions[id_key] ||= subscription_klass.new(connection, id_key, id_options)

--- a/lib/action_cable/server/base.rb
+++ b/lib/action_cable/server/base.rb
@@ -36,11 +36,11 @@ module ActionCable
         @worker_pool ||= ActionCable::Server::Worker.pool(size: config.worker_pool_size)
       end
 
-      # Requires and returns an array of all the channel class constants in this application.
+      # Requires and returns an hash of all the channel class constants keyed by name.
       def channel_classes
         @channel_classes ||= begin
           config.channel_paths.each { |channel_path| require channel_path }
-          config.channel_class_names.collect { |name| name.constantize }
+          config.channel_class_names.each_with_object({}) { |name, hash| hash[name] = name.constantize }
         end
       end
 

--- a/test/connection/subscriptions_test.rb
+++ b/test/connection/subscriptions_test.rb
@@ -20,7 +20,7 @@ class ActionCable::Connection::SubscriptionsTest < ActiveSupport::TestCase
 
   setup do
     @server = TestServer.new
-    @server.stubs(:channel_classes).returns([ ChatChannel ])
+    @server.stubs(:channel_classes).returns(ChatChannel.name => ChatChannel)
 
     env = Rack::MockRequest.env_for "/test", 'HTTP_CONNECTION' => 'upgrade', 'HTTP_UPGRADE' => 'websocket'
     @connection = Connection.new(@server, env)


### PR DESCRIPTION
Current implementation  calls `safe_constantize` at least once and possibly multiple times each time a subscription is added, which is a slow operation. 

Instead, this looks up the channel classes in a hash. 
