### PR TITLE
Fixing documentation, correcting grammar, and removing unnecessary whitespace

### DIFF
--- a/lib/action_cable/channel/streams.rb
+++ b/lib/action_cable/channel/streams.rb
@@ -1,6 +1,6 @@
 module ActionCable
   module Channel
-    # Streams allow channels to route broadcastings to the subscriber. A broadcasting is an discussed elsewhere a pub/sub queue where any data
+    # Streams allow channels to route broadcastings to the subscriber. A broadcasting is, as discussed elsewhere, a pub/sub queue where any data
     # put into it is automatically sent to the clients that are connected at that time. It's purely an online queue, though. If you're not
     # streaming a broadcasting at the very moment it sends out an update, you'll not get that update when connecting later.
     #
@@ -24,7 +24,7 @@ module ActionCable
     #   ActionCable.server.broadcast "comments_for_45", author: 'DHH', content: 'Rails is just swell'
     #
     # If you have a stream that is related to a model, then the broadcasting used can be generated from the model and channel.
-    # The following example would to subscribe to a broadcasting that would be something like `comments:Z2lkOi8vVGVzdEFwcC9Qb3N0LzE`
+    # The following example would subscribe to a broadcasting like `comments:Z2lkOi8vVGVzdEFwcC9Qb3N0LzE`
     #
     #   class CommentsChannel < ApplicationCable::Channel
     #     def subscribed
@@ -37,15 +37,15 @@ module ActionCable
     #
     #   CommentsChannel.broadcast_to(@post)
     #
-    # If you don't just want to parlay the broadcast unfiltered to the subscriber, you can supply a callback that let's you alter what goes out.
+    # If you don't just want to parlay the broadcast unfiltered to the subscriber, you can supply a callback that lets you alter what goes out.
     # Example below shows how you can use this to provide performance introspection in the process:
     #
     #   class ChatChannel < ApplicationCable::Channel
     #    def subscribed
     #      @room = Chat::Room[params[:room_number]]
     #
-    #      stream_for @room, -> (message) do
-    #        message = ActiveSupport::JSON.decode(m)
+    #      stream_for @room, -> (encoded_message) do
+    #        message = ActiveSupport::JSON.decode(encoded_message)
     #
     #        if message['originated_at'].present?
     #          elapsed_time = (Time.now.to_f - message['originated_at']).round(2)

--- a/lib/action_cable/connection/base.rb
+++ b/lib/action_cable/connection/base.rb
@@ -12,7 +12,7 @@ module ActionCable
     #   module ApplicationCable
     #     class Connection < ActionCable::Connection::Base
     #       identified_by :current_user
-    #   
+    #
     #       def connect
     #         self.current_user = find_verified_user
     #         logger.add_tags current_user.name
@@ -21,7 +21,7 @@ module ActionCable
     #       def disconnect
     #         # Any cleanup work needed when the cable connection is cut.
     #       end
-    #   
+    #
     #       protected
     #         def find_verified_user
     #           if current_user = User.find_by_identity cookies.signed[:identity_id]
@@ -37,7 +37,7 @@ module ActionCable
     # established for that current_user (and potentially disconnect them if the user was removed from an account). You can declare as many
     # identification indexes as you like. Declaring an identification means that a attr_accessor is automatically set for that key.
     #
-    # Second, we rely on the fact that the websocket connection is established with the cookies from that domain being sent along. This makes
+    # Second, we rely on the fact that the websocket connection is established with the cookies from the domain being sent along. This makes
     # it easy to use signed cookies that were set when logging in via a web interface to authorize the websocket connection.
     #
     # Finally, we add a tag to the connection-specific logger with name of the current user to easily distinguish their messages in the log.
@@ -75,14 +75,14 @@ module ActionCable
           websocket.on(:open)    { |event| send_async :on_open   }
           websocket.on(:message) { |event| on_message event.data }
           websocket.on(:close)   { |event| send_async :on_close  }
-          
+
           respond_to_successful_request
         else
           respond_to_invalid_request
         end
       end
 
-      # Data received over the cable is handled by this method. It's expected that everything inbound is encoded with JSON. 
+      # Data received over the cable is handled by this method. It's expected that everything inbound is JSON encoded.
       # The data is routed to the proper channel that the connection has subscribed to.
       def receive(data_in_json)
         if websocket.alive?
@@ -177,7 +177,7 @@ module ActionCable
 
         # Tags are declared in the server but computed in the connection. This allows us per-connection tailored tags.
         def new_tagged_logger
-          TaggedLoggerProxy.new server.logger, 
+          TaggedLoggerProxy.new server.logger,
             tags: server.config.log_tags.map { |tag| tag.respond_to?(:call) ? tag.call(request) : tag.to_s.camelize }
         end
 

--- a/lib/action_cable/connection/heartbeat.rb
+++ b/lib/action_cable/connection/heartbeat.rb
@@ -5,7 +5,7 @@ module ActionCable
     # disconnect.
     class Heartbeat
       BEAT_INTERVAL = 3
-      
+
       def initialize(connection)
         @connection = connection
       end
@@ -21,7 +21,7 @@ module ActionCable
 
       private
         attr_reader :connection
-        
+
         def beat
           connection.transmit({ identifier: '_ping', message: Time.now.to_i }.to_json)
         end

--- a/lib/action_cable/connection/identification.rb
+++ b/lib/action_cable/connection/identification.rb
@@ -16,7 +16,7 @@ module ActionCable
         # channel instances created off the connection.
         def identified_by(*identifiers)
           Array(identifiers).each { |identifier| attr_accessor identifier }
-          self.identifiers += identifiers          
+          self.identifiers += identifiers
         end
       end
 

--- a/lib/action_cable/remote_connections.rb
+++ b/lib/action_cable/remote_connections.rb
@@ -25,7 +25,7 @@ module ActionCable
     end
 
     private
-      # Represents a single remote connection found via ActionCable.server.remote_connections.where(*). 
+      # Represents a single remote connection found via ActionCable.server.remote_connections.where(*).
       # Exists for the solely for the purpose of calling #disconnect on that connection.
       class RemoteConnection
         class InvalidIdentifiersError < StandardError; end


### PR DESCRIPTION
Mostly inconsequential changes, but it does include changes to an example in `ActionCable::Channel` that was incorrect.