### PR TITLE
Fixes test failure in ActionCable::Channel::BroadcastingTest when run by itself

### DIFF
--- a/lib/action_cable.rb
+++ b/lib/action_cable.rb
@@ -8,6 +8,7 @@ require 'active_support/json'
 require 'active_support/concern'
 require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/core_ext/module/delegation'
+require 'active_support/core_ext/object/to_param'
 require 'active_support/callbacks'
 
 require 'faye/websocket'


### PR DESCRIPTION
Here's the test output currently:

```
$ ruby -Ilib:test -rtest_helper test/channel/broadcasting_test.rb
Run options: --seed 9529

# Running:

EEEE

Finished in 0.002903s, 1378.0449 runs/s, 0.0000 assertions/s.

  1) Error:
ActionCable::Channel::BroadcastingTest#test_broadcasting_for_with_a_string:
NoMethodError: undefined method `to_param' for "hello":String
    /Users/jasondew/Projects/jasondew-actioncable/lib/action_cable/channel/broadcasting.rb:21:in `broadcasting_for'
    test/channel/broadcasting_test.rb:27:in `block in <class:BroadcastingTest>'


  2) Error:
ActionCable::Channel::BroadcastingTest#test_broadcasting_for_with_an_array:
NoMethodError: undefined method `to_param' for "Room#1-Campfire":String
    /Users/jasondew/Projects/jasondew-actioncable/test/stubs/room.rb:14:in `to_gid_param'
    /Users/jasondew/Projects/jasondew-actioncable/lib/action_cable/channel/broadcasting.rb:19:in `broadcasting_for'
    /Users/jasondew/Projects/jasondew-actioncable/lib/action_cable/channel/broadcasting.rb:17:in `block in broadcasting_for'
    /Users/jasondew/Projects/jasondew-actioncable/lib/action_cable/channel/broadcasting.rb:17:in `map'
    /Users/jasondew/Projects/jasondew-actioncable/lib/action_cable/channel/broadcasting.rb:17:in `broadcasting_for'
    test/channel/broadcasting_test.rb:23:in `block in <class:BroadcastingTest>'


  3) Error:
ActionCable::Channel::BroadcastingTest#test_broadcasting_for_with_an_object:
NoMethodError: undefined method `to_param' for "Room#1-Campfire":String
    /Users/jasondew/Projects/jasondew-actioncable/test/stubs/room.rb:14:in `to_gid_param'
    /Users/jasondew/Projects/jasondew-actioncable/lib/action_cable/channel/broadcasting.rb:19:in `broadcasting_for'
    test/channel/broadcasting_test.rb:19:in `block in <class:BroadcastingTest>'


  4) Error:
ActionCable::Channel::BroadcastingTest#test_broadcasts_to:
NoMethodError: undefined method `to_param' for "action_cable:channel:broadcasting_test:chat":String
    /Users/jasondew/Projects/jasondew-actioncable/lib/action_cable/channel/broadcasting.rb:21:in `broadcasting_for'
    /Users/jasondew/Projects/jasondew-actioncable/lib/action_cable/channel/broadcasting.rb:17:in `block in broadcasting_for'
    /Users/jasondew/Projects/jasondew-actioncable/lib/action_cable/channel/broadcasting.rb:17:in `map'
    /Users/jasondew/Projects/jasondew-actioncable/lib/action_cable/channel/broadcasting.rb:17:in `broadcasting_for'
    /Users/jasondew/Projects/jasondew-actioncable/lib/action_cable/channel/broadcasting.rb:11:in `broadcast_to'
    test/channel/broadcasting_test.rb:15:in `block in <class:BroadcastingTest>'

4 runs, 0 assertions, 0 failures, 4 errors, 0 skips
```

I haven't investigated further to find out where/how we're requiring this when the whole suite is run, but this fixes things up.