### PR TITLE
Move require of to_param to where it is needed

### DIFF
--- a/lib/action_cable.rb
+++ b/lib/action_cable.rb
@@ -8,7 +8,6 @@ require 'active_support/json'
 require 'active_support/concern'
 require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/core_ext/module/delegation'
-require 'active_support/core_ext/object/to_param'
 require 'active_support/callbacks'
 
 require 'faye/websocket'

--- a/lib/action_cable/channel/broadcasting.rb
+++ b/lib/action_cable/channel/broadcasting.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/object/to_param'
+
 module ActionCable
   module Channel
     module Broadcasting


### PR DESCRIPTION
#49 Added a require of  `active_support/core_ext/object/to_param` to make the broadcasting specs run by themselves. 

This require should only be needed for `lib/action_cable/channel/broadcasting.rb`, so this PR moves the require to this file.