### PR TITLE
Clear out the streams when they are stopped.

### DIFF
--- a/lib/action_cable/channel/streams.rb
+++ b/lib/action_cable/channel/streams.rb
@@ -88,7 +88,7 @@ module ActionCable
         streams.each do |broadcasting, callback|
           pubsub.unsubscribe_proc broadcasting, callback
           logger.info "#{self.class.name} stopped streaming from #{broadcasting}"
-        end
+        end.clear
       end
 
       private


### PR DESCRIPTION
When `stop_all_streams` is called, the streams are left in the channels `streams`. So then next time `stop_all_streams` is called, it will try and stop the same streams again. 

It looks like that if a channel is designed to persist the entire duration of a users session, it will continue to accumulate more and more streams.

This PR adds clears out the streams after stoping them, to prevent a accumulation of inactive streams.