### PR TITLE
Remove out-of-date AC::Broadcaster reference

### DIFF
--- a/lib/action_cable.rb
+++ b/lib/action_cable.rb
@@ -22,9 +22,7 @@ module ActionCable
   autoload :Server, 'action_cable/server'
   autoload :Connection, 'action_cable/connection'
   autoload :Channel, 'action_cable/channel'
-
   autoload :RemoteConnections, 'action_cable/remote_connections'
-  autoload :Broadcaster, 'action_cable/broadcaster'
 
   # Singleton instance of the server
   module_function def server


### PR DESCRIPTION
Remove out-of-data autoload reference of ActionCable::Broadcaster that removed at e1a99a83ca135523ff8513be756f156500999cb8 .