### PR TITLE
Support connection identifiers that don't implement to_global_id

### DIFF
--- a/lib/action_cable/connection/identification.rb
+++ b/lib/action_cable/connection/identification.rb
@@ -27,7 +27,7 @@ module ActionCable
 
       private
         def connection_gid(ids)
-          ids.map { |o| o.to_global_id.to_s }.sort.join(":")
+          ids.map { |o| (o.try(:to_global_id) || o).to_s }.sort.join(":")
         end
     end
   end

--- a/test/connection/string_identifier_test.rb
+++ b/test/connection/string_identifier_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+require 'stubs/test_server'
+
+class ActionCable::Connection::StringIdentifierTest < ActiveSupport::TestCase
+  class Connection < ActionCable::Connection::Base
+    identified_by :current_token
+
+    def connect
+      self.current_token = "random-string"
+    end
+  end
+
+  setup do
+    @server = TestServer.new
+
+    env = Rack::MockRequest.env_for "/test", 'HTTP_CONNECTION' => 'upgrade', 'HTTP_UPGRADE' => 'websocket'
+    @connection = Connection.new(@server, env)
+  end
+
+  test "connection identifier" do
+    open_connection_with_stubbed_pubsub
+    assert_equal "random-string", @connection.connection_identifier
+  end
+
+  protected
+    def open_connection_with_stubbed_pubsub
+      @server.stubs(:pubsub).returns(stub_everything('pubsub'))
+      open_connection
+    end
+
+    def open_connection
+      @connection.process
+      @connection.send :on_open
+    end
+
+    def close_connection
+      @connection.send :on_close
+    end
+end


### PR DESCRIPTION
This is related to #63 

Previously, issues would occur when constructing the `connection_gid` in `ActionCable::Connection::Identification` as it would attempt to call `to_global_id` on the identifier even if it didn't have such a method. 

This change allows us to use identifiers that don't implement `to_global_id`.

Any suggestions welcomed.