### PR TITLE
Use ActiveSupport::Callbacks for Channel subscription callbacks.

### DIFF
--- a/lib/action_cable/channel/base.rb
+++ b/lib/action_cable/channel/base.rb
@@ -71,9 +71,6 @@ module ActionCable
       include Naming
       include Broadcasting
 
-      on_subscribe   :subscribed
-      on_unsubscribe :unsubscribed
-
       attr_reader :params, :connection
       delegate :logger, to: :connection
 
@@ -138,7 +135,9 @@ module ActionCable
       # Called by the cable connection when its cut so the channel has a chance to cleanup with callbacks.
       # This method is not intended to be called directly by the user. Instead, overwrite the #unsubscribed callback.
       def unsubscribe_from_channel
-        run_unsubscribe_callbacks
+        run_callbacks :unsubscribe do
+          unsubscribed
+        end
         logger.info "#{self.class.name} unsubscribed"
       end
 
@@ -176,7 +175,9 @@ module ActionCable
 
         def subscribe_to_channel
           logger.info "#{self.class.name} subscribing"
-          run_subscribe_callbacks
+          run_callbacks :subscribe do
+            subscribed
+          end
         end
 
 
@@ -204,14 +205,6 @@ module ActionCable
               signature << "(#{arguments.inspect})"
             end
           end
-        end
-
-        def run_subscribe_callbacks
-          self.class.on_subscribe_callbacks.each { |callback| send(callback) }
-        end
-
-        def run_unsubscribe_callbacks
-          self.class.on_unsubscribe_callbacks.each { |callback| send(callback) }
         end
     end
   end

--- a/lib/action_cable/channel/callbacks.rb
+++ b/lib/action_cable/channel/callbacks.rb
@@ -1,27 +1,35 @@
+require 'active_support/callbacks'
+
 module ActionCable
   module Channel
     module Callbacks
-      extend ActiveSupport::Concern
+      extend  ActiveSupport::Concern
+      include ActiveSupport::Callbacks
 
       included do
-        class_attribute :on_subscribe_callbacks, :on_unsubscribe_callbacks, instance_reader: false
-
-        self.on_subscribe_callbacks = []
-        self.on_unsubscribe_callbacks = []
+        define_callbacks :subscribe
+        define_callbacks :unsubscribe
       end
 
-      module ClassMethods
-        # Name methods that should be called when the channel is subscribed to.
-        # (These methods should be private, so they're not callable by the user).
-        def on_subscribe(*methods)
-          self.on_subscribe_callbacks += methods
+      class_methods do
+        def before_subscribe(*methods, &block)
+          set_callback(:subscribe, :before, *methods, &block)
         end
 
-        # Name methods that should be called when the channel is unsubscribed from.
-        # (These methods should be private, so they're not callable by the user).
-        def on_unsubscribe(*methods)
-          self.on_unsubscribe_callbacks += methods
+        def after_subscribe(*methods, &block)
+          set_callback(:subscribe, :after, *methods, &block)
         end
+        alias_method :on_subscribe, :after_subscribe
+
+
+        def before_unsubscribe(*methods, &block)
+          set_callback(:unsubscribe, :before, *methods, &block)
+        end
+
+        def after_unsubscribe(*methods, &block)
+          set_callback(:unsubscribe, :after, *methods, &block)
+        end
+        alias_method :on_unsubscribe, :after_unsubscribe
       end
     end
   end

--- a/lib/action_cable/channel/periodic_timers.rb
+++ b/lib/action_cable/channel/periodic_timers.rb
@@ -7,8 +7,8 @@ module ActionCable
         class_attribute :periodic_timers, instance_reader: false
         self.periodic_timers = []
 
-        on_subscribe   :start_periodic_timers
-        on_unsubscribe :stop_periodic_timers
+        after_subscribe   :start_periodic_timers
+        after_unsubscribe :stop_periodic_timers
       end
 
       module ClassMethods

--- a/test/channel/base_test.rb
+++ b/test/channel/base_test.rb
@@ -20,8 +20,8 @@ class ActionCable::Channel::BaseTest < ActiveSupport::TestCase
 
   class ChatChannel < BasicChannel
     attr_reader :room, :last_action
-    on_subscribe :toggle_subscribed
-    on_unsubscribe :toggle_subscribed
+    after_subscribe :toggle_subscribed
+    after_unsubscribe :toggle_subscribed
 
     def subscribed
       @room = Room.new params[:id]


### PR DESCRIPTION
(As mentioned in #32)

 * Rely on AS::Callbacks for callback handling.
 * Add before_subscribe, after_subscribe, before_unsubscribe and
   after_unsubscribe convenience methods
 * alias on_subscribe and on_unsubscribe to after_subscribe and
   after_unsubscribe, respectively.
 * Remove `subscribed` and `unsubscribed` from the callback chain:
   these methods are now executed as the *subject* of the callbacks.
 * Update portions of ActionCable to use the more specific
   callback names.