### PR TITLE
Сlient refactoring in order to support CommonJS modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,13 @@
 test/tests.log
+
+node_modules/
+npm-debug.log
+
+dist/*
+!dist/.keep
+
+test/sprockets/cable.js
+
+.vagrant/
+bootstrap.sh
+Vagrantfile

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,10 @@
+lib/action_cable
+lib/*.rb
+test/
+actioncable.gemspec
+Rakefile
+Gemfile
+Gemfile.lock
+.ruby-version
+bootstrap.sh
+Vagrantfile

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,8 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
     redis (3.2.1)
+    sprockets (3.3.3)
+      rack (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     timers (4.0.1)
@@ -102,6 +104,7 @@ DEPENDENCIES
   mocha
   puma
   rake
+  sprockets
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/NPM.md
+++ b/NPM.md
@@ -1,0 +1,10 @@
+## Working with npm
+
+* `npm install` - will install all devtools to local node_modules/ directory
+* `npm run build` - will build CommonJS compatible module in dist/index.js
+* `npm run test` - will run tests for CommonJS module
+* `npm run test-sprockets` - will run tests for sprockets packaged module (using PhantomJS)
+* `npm run pack` - will create npm package with pre-compiled and ready-to-use in CommonJS bundlers(browserify, webpack) actioncable client
+
+## Known issues
+`npm install` will download pre-compiled phantomjs binaries, but if you use ubuntu, you should additionally install some font pckages `apt-get install libfreetype6-dev libfontconfig1-dev`

--- a/actioncable.gemspec
+++ b/actioncable.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'puma'
   s.add_development_dependency 'mocha'
+  s.add_development_dependency 'sprockets'
 
   s.files = Dir['README', 'lib/**/*']
   s.has_rdoc = false

--- a/lib/assets/javascripts/cable.js.coffee
+++ b/lib/assets/javascripts/cable.js.coffee
@@ -1,4 +1,8 @@
 #= require_self
+#= require cable/connection
+#= require cable/connection_monitor
+#= require cable/subscriptions
+#= require cable/subscription
 #= require cable/consumer
 
 @Cable =

--- a/lib/assets/javascripts/cable/connection.js.coffee
+++ b/lib/assets/javascripts/cable/connection.js.coffee
@@ -1,4 +1,9 @@
 # Encapsulate the cable connection held by the consumer. This is an internal class not intended for direct user manipulation.
+Cable = if typeof window == 'object'
+  window.Cable
+else if typeof global == 'object'
+  global.Cable
+
 class Cable.Connection
   constructor: (@consumer) ->
     @open()

--- a/lib/assets/javascripts/cable/connection_monitor.js.coffee
+++ b/lib/assets/javascripts/cable/connection_monitor.js.coffee
@@ -1,5 +1,11 @@
 # Responsible for ensuring the cable connection is in good health by validating the heartbeat pings sent from the server, and attempting
 # revival reconnections if things go astray. Internal class, not intended for direct user manipulation.
+
+Cable = if typeof window == 'object'
+  window.Cable
+else if typeof global == 'object'
+  global.Cable
+
 class Cable.ConnectionMonitor
   identifier: Cable.PING_IDENTIFIER
 

--- a/lib/assets/javascripts/cable/consumer.js.coffee
+++ b/lib/assets/javascripts/cable/consumer.js.coffee
@@ -1,8 +1,3 @@
-#= require cable/connection
-#= require cable/connection_monitor
-#= require cable/subscriptions
-#= require cable/subscription
-
 # The Cable.Consumer establishes the connection to a server-side Ruby Connection object. Once established,
 # the Cable.ConnectionMonitor will ensure that its properly maintained through heartbeats and checking for stale updates.
 # The Consumer instance is also the gateway to establishing subscriptions to desired channels through the #createSubscription
@@ -15,6 +10,12 @@
 #   App.appearance = App.cable.subscriptions.create "AppearanceChannel"
 #
 # For more details on how you'd configure an actual channel subscription, see Cable.Subscription.
+
+Cable = if typeof window == 'object'
+  window.Cable
+else if typeof global == 'object'
+  global.Cable
+
 class Cable.Consumer
   constructor: (@url) ->
     @subscriptions = new Cable.Subscriptions this

--- a/lib/assets/javascripts/cable/subscription.js.coffee
+++ b/lib/assets/javascripts/cable/subscription.js.coffee
@@ -1,5 +1,5 @@
-# A new subscription is created through the Cable.Subscriptions instance available on the consumer. 
-# It provides a number of callbacks and a method for calling remote procedure calls on the corresponding 
+# A new subscription is created through the Cable.Subscriptions instance available on the consumer.
+# It provides a number of callbacks and a method for calling remote procedure calls on the corresponding
 # Channel instance on the server side.
 #
 # An example demonstrates the basic functionality:
@@ -7,13 +7,13 @@
 #   App.appearance = App.cable.subscriptions.create "AppearanceChannel",
 #     connected: ->
 #       # Called once the subscription has been successfully completed
-#   
+#
 #     appear: ->
 #       @perform 'appear', appearing_on: @appearingOn()
-#   
+#
 #     away: ->
 #       @perform 'away'
-#   
+#
 #     appearingOn: ->
 #       $('main').data 'appearing-on'
 #
@@ -27,15 +27,15 @@
 #     def subscribed
 #       current_user.appear
 #     end
-#   
+#
 #     def unsubscribed
 #       current_user.disappear
 #     end
-#   
+#
 #     def appear(data)
 #       current_user.appear on: data['appearing_on']
 #     end
-#   
+#
 #     def away
 #       current_user.away
 #     end
@@ -43,6 +43,11 @@
 #
 # The "AppearanceChannel" name is automatically mapped between the client-side subscription creation and the server-side Ruby class name.
 # The AppearanceChannel#appear/away public methods are exposed automatically to client-side invocation through the @perform method.
+Cable = if typeof window == 'object'
+  window.Cable
+else if typeof global == 'object'
+  global.Cable
+
 class Cable.Subscription
   constructor: (@subscriptions, params = {}, mixin) ->
     @identifier = JSON.stringify(params)

--- a/lib/assets/javascripts/cable/subscriptions.js.coffee
+++ b/lib/assets/javascripts/cable/subscriptions.js.coffee
@@ -6,6 +6,11 @@
 #   App.appearance = App.cable.subscriptions.create "AppearanceChannel"
 #
 # For more details on how you'd configure an actual channel subscription, see Cable.Subscription.
+Cable = if typeof window == 'object'
+  window.Cable
+else if typeof global == 'object'
+  global.Cable
+
 class Cable.Subscriptions
   constructor: (@consumer) ->
     @subscriptions = []

--- a/lib/assets/javascripts/index.js.coffee
+++ b/lib/assets/javascripts/index.js.coffee
@@ -1,0 +1,18 @@
+Cable =
+  PING_IDENTIFIER: "_ping"
+
+  createConsumer: (url) ->
+    new Cable.Consumer url
+
+if typeof window == 'object'
+  window.Cable = Cable
+else if typeof global == 'object'
+  global.Cable = Cable
+
+require('./cable/connection.js.coffee')
+require('./cable/connection_monitor.js.coffee')
+require('./cable/subscription.js.coffee')
+require('./cable/subscriptions.js.coffee')
+require('./cable/consumer.js.coffee')
+
+module.exports = Cable;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "actioncable",
+  "version": "0.0.3",
+  "description": "Client for rails's actioncable",
+  "author": "",
+  "main": "dist/index.js",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rails/actioncable"
+  },
+  "scripts": {
+    "build": "webpack --config webpack.config.js",
+    "prepublish": "npm run build",
+    "test": "mocha --compilers coffee:coffee-script/register test/javascripts",
+    "test-sprockets": "ruby test/sprockets/build.rb && mocha-phantomjs test/sprockets/runner.html"
+  },
+  "devDependencies": {
+    "chai": "^3.2.0",
+    "coffee-loader": "^0.7.2",
+    "coffee-script": "^1.9.3",
+    "mocha": "^2.2.5",
+    "mocha-phantomjs": "^3.6.0",
+    "phantomjs": "=1.9.7-15",
+    "webpack": "^1.12.0"
+  }
+}

--- a/test/javascripts/packaging_test.coffee
+++ b/test/javascripts/packaging_test.coffee
@@ -1,0 +1,24 @@
+expect = require('chai').expect;
+Cable = require('../../lib/assets/javascripts/index.js.coffee');
+
+describe 'Cable should expose all modules', ->
+  it 'contains PING_IDENTIFIER', ->
+    expect(Cable.PING_IDENTIFIER).to.equal '_ping'
+
+  it 'contains createConsumer function', ->
+    expect(typeof Cable.createConsumer).to.equal 'function'
+
+  it 'contains Connection class', ->
+    expect(typeof Cable.Connection).to.equal 'function'
+
+  it 'contains ConnectionMonitor class', ->
+    expect(typeof Cable.ConnectionMonitor).to.equal 'function'
+
+  it 'contains Subscription class', ->
+    expect(typeof Cable.Subscription).to.equal 'function'
+
+  it 'contains Subscriptions class', ->
+    expect(typeof Cable.Subscriptions).to.equal 'function'
+
+  it 'contains Consumer class', ->
+    expect(typeof Cable.Consumer).to.equal 'function'

--- a/test/sprockets/build.rb
+++ b/test/sprockets/build.rb
@@ -1,0 +1,6 @@
+require 'sprockets'
+
+environment = Sprockets::Environment.new
+environment.append_path 'lib/assets/javascripts'
+
+environment.find_asset('cable.js.coffee').write_to('test/sprockets/cable.js');

--- a/test/sprockets/packaging_test.js
+++ b/test/sprockets/packaging_test.js
@@ -1,0 +1,29 @@
+describe('Cable should expose all modules', function() {
+  it('contains PING_IDENTIFIER', function() {
+    expect(Cable.PING_IDENTIFIER).to.equal('_ping');
+  });
+
+  it('contains createConsumer function', function() {
+    expect(typeof Cable.createConsumer).to.equal('function');
+  });
+
+  it('contains Connection class', function() {
+    expect(typeof Cable.Connection).to.equal('function');
+  });
+
+  it('contains ConnectionMonitor class', function() {
+    expect(typeof Cable.ConnectionMonitor).to.equal('function');
+  });
+
+  it('contains Subscription class', function() {
+    expect(typeof Cable.Subscription).to.equal('function');
+  });
+
+  it('contains Subscriptions class', function() {
+    expect(typeof Cable.Subscriptions).to.equal('function');
+  });
+
+  it('contains Consumer class', function() {
+    expect(typeof Cable.Consumer).to.equal('function');
+  });
+});

--- a/test/sprockets/runner.html
+++ b/test/sprockets/runner.html
@@ -1,0 +1,23 @@
+<html>
+  <head>
+    <meta charset="utf-8">
+    <!-- encoding must be set for mocha's special characters to render properly -->
+    <link rel="stylesheet" href="../../node_modules/mocha/mocha.css" />
+  </head>
+  <body>
+    <div id="mocha"></div>
+    <script src="../../node_modules/mocha/mocha.js"></script>
+    <script src="../../node_modules/chai/chai.js"></script>
+    <script>
+      mocha.ui('bdd');
+      mocha.reporter('html');
+      expect = chai.expect;
+    </script>
+    <script src="./cable.js"></script>
+    <script src="./packaging_test.js"></script>
+    <script>
+      if (window.mochaPhantomJS) { mochaPhantomJS.run(); }
+      else { mocha.run(); }
+    </script>
+  </body>
+</html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,24 @@
+var path = require('path');
+var webpack = require('webpack');
+
+module.exports = {
+  entry: [
+    './lib/assets/javascripts/index.js.coffee'
+  ],
+
+  output: {
+    path:     path.join(__dirname, 'dist/'),
+    filename: 'index.js',
+    library: 'Cable',
+    libraryTarget: 'umd'
+  },
+
+  module: {
+    loaders: [
+      {
+        test: /\.coffee$/,
+        loader: 'coffee'
+      }
+    ]
+  }
+};


### PR DESCRIPTION
Since more and more people choose CommonJS or ES6 modules for resolving dependencies in client-side codebase, I think that actioncable client should support CommonJS modules, and should provide npm package for fast and easy integration with modern asset bundlers, like browserify or webpack.

I've done a little work on support for CommonJS modules (compatibility with sprockets has saved).
I've also added a few tests to ensure that these changes haven't broke top-level module API's.

With this changes client-side code doesn't look pretty clear, so I think we should review ability to move development of client to CommonJS only modules, and include to gem already pre-compiled version which will be compatible with sprockets.

[Vagrantfile](https://gist.github.com/ascrazy/12395e5daa3e55360deb)