### PR TITLE
Capture when redis subscription is definitely active

### DIFF
--- a/lib/action_cable/channel/streams.rb
+++ b/lib/action_cable/channel/streams.rb
@@ -72,7 +72,8 @@ module ActionCable
         callback ||= default_stream_callback(broadcasting)
 
         streams << [ broadcasting, callback ]
-        pubsub.subscribe broadcasting, &callback
+        deferred = pubsub.subscribe broadcasting, &callback
+        deferred.callback { callback.call '"subscribed"' }
 
         logger.info "#{self.class.name} is streaming from #{broadcasting}"
       end

--- a/lib/assets/javascripts/cable/connection.coffee
+++ b/lib/assets/javascripts/cable/connection.coffee
@@ -44,7 +44,11 @@ class Cable.Connection
   events:
     message: (event) ->
       {identifier, message} = JSON.parse(event.data)
-      @consumer.subscriptions.notify(identifier, "received", message)
+
+      if message == "subscribed"
+        @consumer.subscriptions.notify(identifier, "subscribed")
+      else
+        @consumer.subscriptions.notify(identifier, "received", message)
 
     open: ->
       @disconnected = false


### PR DESCRIPTION
This pull request demonstrates why I am getting a race condition in issue #74. This probably isn't ideal for the solution, but I would love to be involved in the final solution.

A couple thoughts I've had:
* Maybe the client doesn't notify "connected" until the subscription is active?
* This current solution is a problem if you want to send "subscribed" as a message to the client... perhaps the final solution should have no such possible clash?
* Maybe there is a way to wait for the redis subscription before continuing with the socket connection so the connection message is actually connected and subscribed...?
* Maybe there are similar sort of issues when a reconnect needs to happen?