### PR TITLE
Allow relative urls for createCable

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ Example::Application.routes.draw do
 end
 ```
 
-You can use `App.cable.createConsumer('ws://' + window.location.host + '/websocket')` to connect to the cable server.
+You can use `App.cable.createConsumer('/websocket')` to connect to the cable server.
 
 For every instance of your server you create and for every worker your server spawns, you will also have a new instance of ActionCable, but the use of Redis keeps messages synced across connections.
 

--- a/lib/assets/javascripts/cable.coffee.erb
+++ b/lib/assets/javascripts/cable.coffee.erb
@@ -5,8 +5,19 @@
   INTERNAL: <%= ActionCable::INTERNAL.to_json %>
 
   createConsumer: (url = @getConfig("url")) ->
-    new Cable.Consumer url
+    new Cable.Consumer webSocketURL(url)
 
   getConfig: (name) ->
     element = document.head.querySelector("meta[name='action-cable-#{name}']")
     element?.getAttribute("content")
+
+  webSocketURL = (url) ->
+    if url and not /^wss?:/i.test(url)
+      a = document.createElement("a")
+      a.href = url
+      # in internet explorer, the next line properly populates the protocol
+      a.href = a.href
+      a.protocol = a.protocol.replace("http", "ws")
+      a.href
+    else
+      url


### PR DESCRIPTION
If you are running the websocket channel in puma along with rails, the following solution can address #72 - This lets you pass in an absolute or relative url, with or without a host/port.

This can be added after the code in #73, if that solution is also desired.

If this looks good, I can spend some time adding support for IE6 and more edge cases. See [gist](https://gist.github.com/jlong/2428561) by @jlong for more information.
