### PR TITLE
add configuration for allowed_requrest_origins to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ require ::File.expand_path('../../config/environment',  __FILE__)
 Rails.application.eager_load!
 
 require 'action_cable/process/logging'
-
+ActionCable.server.config.allowed_request_origins = ["http://localhost:3000"]
 run ActionCable.server
 ```
 


### PR DESCRIPTION
I am getting `Request origin not allowed: http://localhost:3000` errors since #85 was merged.

This adds example config to allow requests to be made that pass this protection.

NOTE: I tried putting this into the config/environments/*.rb files but it caused issues with the server.logger being nil. I think that we need a `actioncable/railtie` to manage configuring the server at the correct point of the application load process. Would there be interest in a railtie or should that wait until actionable is being merged into rails.
