### PR TITLE
add railtie and set default allowed_request_origins for development

### DIFF
--- a/lib/action_cable.rb
+++ b/lib/action_cable.rb
@@ -17,6 +17,8 @@ require 'em-hiredis'
 require 'redis'
 
 require 'action_cable/engine' if defined?(Rails)
+require 'action_cable/railtie' if defined?(Rails)
+
 require 'action_cable/version'
 
 module ActionCable

--- a/lib/action_cable/railtie.rb
+++ b/lib/action_cable/railtie.rb
@@ -1,0 +1,19 @@
+module ActionCable
+  class Railtie < Rails::Railtie
+    config.action_cable = ActiveSupport::OrderedOptions.new
+
+    initializer "action_cable.logger" do
+      ActiveSupport.on_load(:action_cable) { self.logger ||= ::Rails.logger }
+    end
+
+    initializer "action_cable.set_configs" do |app|
+      options = app.config.action_cable
+
+      options.allowed_request_origins ||= "http://localhost:3000" if ::Rails.env.development?
+
+      ActiveSupport.on_load(:action_cable) do
+        options.each { |k,v| send("#{k}=", v) }
+      end
+    end
+  end
+end

--- a/lib/action_cable/server/base.rb
+++ b/lib/action_cable/server/base.rb
@@ -66,5 +66,7 @@ module ActionCable
         config.connection_class.identifiers
       end
     end
+
+    ActiveSupport.run_load_hooks(:action_cable, Base.config)
   end
 end


### PR DESCRIPTION
Add railtie and set default value for allowed_request_origins to http://localhost:3000 for development.

This might be a bit restrictive for people who develop on a different host (like a *.dev) or different ports, so this should change to "*" once support for wildcards in `allowed_request_origins` is supported.

Alternatively, could set `disable_request_forgery_protection` to development.

As discusses in #90.

/cc @kaspth 