### PR TITLE
Fix tests and Travis builds

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,4 +104,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/test/channel/stream_test.rb
+++ b/test/channel/stream_test.rb
@@ -19,14 +19,16 @@ class ActionCable::Channel::StreamTest < ActiveSupport::TestCase
   test "streaming start and stop" do
     @connection.expects(:pubsub).returns mock().tap { |m| m.expects(:subscribe).with("test_room_1") }
     channel = ChatChannel.new @connection, "{id: 1}", { id: 1 }
-
+    EM.run_deferred_callbacks
     @connection.expects(:pubsub).returns mock().tap { |m| m.expects(:unsubscribe_proc) }
     channel.unsubscribe_from_channel
+    EM.run_deferred_callbacks
   end
 
   test "stream_for" do
     @connection.expects(:pubsub).returns mock().tap { |m| m.expects(:subscribe).with("action_cable:channel:stream_test:chat:Room#1-Campfire") }
     channel = ChatChannel.new @connection, ""
     channel.stream_for Room.new(1)
+    EM.run_deferred_callbacks
   end
 end

--- a/test/connection/identifier_test.rb
+++ b/test/connection/identifier_test.rb
@@ -12,6 +12,9 @@ class ActionCable::Connection::IdentifierTest < ActiveSupport::TestCase
     def connect
       self.current_user = User.new "lifo"
     end
+
+    def send_async *args
+    end
   end
 
   setup do

--- a/test/connection/identifier_test.rb
+++ b/test/connection/identifier_test.rb
@@ -32,16 +32,18 @@ class ActionCable::Connection::IdentifierTest < ActiveSupport::TestCase
     @server.expects(:pubsub).returns(pubsub)
 
     open_connection
+    EM.run_deferred_callbacks
   end
 
   test "should unsubscribe from internal channel on close" do
     open_connection_with_stubbed_pubsub
+    EM.run_deferred_callbacks
 
     pubsub = mock('pubsub')
     pubsub.expects(:unsubscribe_proc).with('action_cable/User#lifo', kind_of(Proc))
     @server.expects(:pubsub).returns(pubsub)
-
     close_connection
+    EM.run_deferred_callbacks
   end
 
   test "processing disconnect message" do

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -4,6 +4,8 @@ class WorkerTest < ActiveSupport::TestCase
   class Receiver
     attr_accessor :last_action
 
+    attr_reader :connection
+
     def run
       @last_action = :run
     end


### PR DESCRIPTION
Add connection method to the WorkerTest::Receiver, the connection is being read from the receiver in Worker#run_periodic_timer and this is causing the tests to fail.

Force EM.next_tick to execute with `EM.run_deferred_callbacks`

Currently the tests are passing for me, but the build is still failing on travis with `NoMethodError: undefined method `worker_pool' for #<TestServer:0x00000003bf7f68>`