### PR TITLE
Re upgrading Celluloid to 0.17.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ PATH
     actioncable (0.0.3)
       actionpack (>= 4.2.0)
       activesupport (>= 4.2.0)
-      celluloid (~> 0.16.0)
+      celluloid (~> 0.17, >= 0.17.2)
       coffee-rails
       em-hiredis (~> 0.3.0)
       faye-websocket (~> 0.10.0)
@@ -59,8 +59,23 @@ GEM
   remote: https://rubygems.org/
   specs:
     builder (3.2.2)
-    celluloid (0.16.1)
-      timers (~> 4.0.0)
+    celluloid (0.17.2)
+      celluloid-essentials
+      celluloid-extras
+      celluloid-fsm
+      celluloid-pool
+      celluloid-supervision
+      timers (>= 4.1.1)
+    celluloid-essentials (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-extras (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-fsm (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-pool (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-supervision (0.20.5)
+      timers (>= 4.1.1)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -107,7 +122,7 @@ GEM
     redis (3.2.1)
     thor (0.19.1)
     thread_safe (0.3.5)
-    timers (4.0.4)
+    timers (4.1.1)
       hitimes
     tzinfo (1.2.2)
       thread_safe (~> 0.1)

--- a/actioncable.gemspec
+++ b/actioncable.gemspec
@@ -18,8 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'actionpack',       '>= 4.2.0'
   s.add_dependency 'faye-websocket',   '~> 0.10.0'
   s.add_dependency 'websocket-driver', '~> 0.6.1'
-  # Use 0.16.0 until https://github.com/celluloid/celluloid/issues/637 is resolved
-  s.add_dependency 'celluloid',        '~> 0.16.0'
+  s.add_dependency 'celluloid',        '~> 0.17', '>= 0.17.2'
   s.add_dependency 'em-hiredis',       '~> 0.3.0'
   s.add_dependency 'redis',            '~> 3.0'
   s.add_dependency 'coffee-rails'


### PR DESCRIPTION
As downgraded in: https://github.com/rails/actioncable/pull/37, Celluloid 0.17.2 seems to fix the issues that it has with Spring. This means ActionCable is free to move forward on Celluloid 0.17.2. Example showing the issue is fixed:

```shell
time rails r 'puts "Celluloid @ #{Celluloid::VERSION}, Spring @ #{defined?(Spring) ? Spring::VERSION : "-"}"'
Celluloid @ 0.17.2, Spring @ 1.4.0

real	0m0.654s
user	0m0.408s
sys	0m0.036s
```

```shell
time rails r 'puts "Celluloid @ #{Celluloid::VERSION}, Spring @ #{defined?(Spring) ? Spring::VERSION : "-"}"'
I, [2015-10-14T21:41:51.180579 #24031]  INFO -- : Celluloid 0.17.2 is running in BACKPORTED mode. [ http://git.io/vJf3J ]
Celluloid @ 0.17.2, Spring @ -

real	0m1.967s
user	0m1.670s
sys	0m0.168s
```

There are currently 4 failing tests and 2 errors in the test suite that are failing for the master branch. The test suite also seems to deadlock when run with certain seeds (4042 was one), but I do not believe that to have any relation to celluloid's version.