### PR TITLE
Speed up tests be calling EM.run_deferred_callbacks instead of setting a timer

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,7 +33,8 @@ class ActionCable::TestCase < ActiveSupport::TestCase
     EM.run do
       yield
 
-      EM::Timer.new(0.1) { EM.stop }
+      EM.run_deferred_callbacks
+      EM.stop
     end
   end
 end


### PR DESCRIPTION
The `run_in_eventmachine` test helper method is setting a 0.1 second timer to stop the event machine loop. This causes each test that requires an event machine loop to wait for 0.1 second regardless of how long the test takes to process.

This changes that to call `EM.run_deferred_callbacks`, which immediatly process pending actions in the event loop and then is able to exit the event loop without doing any waiting.

Before this change, running tests produced

    Finished in 2.957857s, 15.8899 runs/s, 27.7228 assertions/s.

After, the tests get

    Finished in 0.065942s, 712.7514 runs/s, 1243.5237 assertions/s.