### PR TITLE
Fix an error when using multiple gid identifiers

### DIFF
--- a/lib/action_cable/connection/identification.rb
+++ b/lib/action_cable/connection/identification.rb
@@ -35,7 +35,7 @@ module ActionCable
         def connection_gid(ids)
           ids.map do |o|
             if o.respond_to? :to_global_id
-              o.to_global_id
+              o.to_global_id.to_s
             else
               o.to_s
             end

--- a/lib/action_cable/connection/identification.rb
+++ b/lib/action_cable/connection/identification.rb
@@ -34,8 +34,8 @@ module ActionCable
       private
         def connection_gid(ids)
           ids.map do |o|
-            if o.respond_to? :to_global_id
-              o.to_global_id.to_s
+            if o.respond_to? :to_gid_param
+              o.to_gid_param
             else
               o.to_s
             end

--- a/test/connection/multiple_identifiers_test.rb
+++ b/test/connection/multiple_identifiers_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+require 'stubs/test_server'
+require 'stubs/user'
+
+class ActionCable::Connection::MultipleIdentifiersTest < ActionCable::TestCase
+  class Connection < ActionCable::Connection::Base
+    identified_by :current_user, :current_room
+
+    def connect
+      self.current_user = User.new "lifo"
+      self.current_room = Room.new "my", "room"
+    end
+  end
+
+  test "multiple connection identifiers" do
+    run_in_eventmachine do
+      open_connection_with_stubbed_pubsub
+      assert_equal "Room#my-room:User#lifo", @connection.connection_identifier
+    end
+  end
+
+  protected
+    def open_connection_with_stubbed_pubsub
+      server = TestServer.new
+      server.stubs(:pubsub).returns(stub_everything('pubsub'))
+
+      open_connection server: server
+    end
+
+    def open_connection(server:)
+      env = Rack::MockRequest.env_for "/test", 'HTTP_CONNECTION' => 'upgrade', 'HTTP_UPGRADE' => 'websocket'
+      @connection = Connection.new(server, env)
+
+      @connection.process
+      @connection.send :on_open
+    end
+
+    def close_connection
+      @connection.send :on_close
+    end
+end

--- a/test/stubs/global_id.rb
+++ b/test/stubs/global_id.rb
@@ -1,0 +1,8 @@
+class GlobalID
+  attr_reader :uri
+  delegate :to_param, :to_s, to: :uri
+
+  def initialize(gid, options = {})
+    @uri = gid
+  end
+end

--- a/test/stubs/room.rb
+++ b/test/stubs/room.rb
@@ -7,7 +7,7 @@ class Room
   end
 
   def to_global_id
-    "Room##{id}-#{name}"
+    GlobalID.new("Room##{id}-#{name}")
   end
 
   def to_gid_param

--- a/test/stubs/user.rb
+++ b/test/stubs/user.rb
@@ -6,6 +6,6 @@ class User
   end
 
   def to_global_id
-    "User##{name}"
+    GlobalID.new("User##{name}")
   end
 end

--- a/test/stubs/user.rb
+++ b/test/stubs/user.rb
@@ -8,4 +8,8 @@ class User
   def to_global_id
     GlobalID.new("User##{name}")
   end
+
+  def to_gid_param
+    to_global_id.to_param
+  end
 end


### PR DESCRIPTION
When using multiple ``identified_by`` identifiers that respond to ``to_global_id``, you get a comparison error.  This is because we call ``.sort`` on the array.

This change fixes the issue since strings can always be sorted properly.