### PR TITLE
Point Broadcasting Redis to Event Machine Redis

### DIFF
--- a/lib/action_cable/server/base.rb
+++ b/lib/action_cable/server/base.rb
@@ -61,6 +61,16 @@ module ActionCable
             # @connections.map &:close
           end
         end
+      rescue RuntimeError
+        ensure_em
+        retry unless (tries -= 1).zero?
+      end
+
+      # Very Rarely EM might die so needs to have a thread established to turn it back on
+      def ensure_em
+        unless EventMachine.reactor_running? && EventMachine.reactor_thread.alive?
+          Thread.new { EventMachine.run }
+        end
       end
 
       # All the identifiers applied to the connection class associated with this server.

--- a/lib/action_cable/server/broadcasting.rb
+++ b/lib/action_cable/server/broadcasting.rb
@@ -31,11 +31,6 @@ module ActionCable
         Broadcaster.new(self, broadcasting)
       end
 
-      # The redis instance used for broadcasting. Not intended for direct user use.
-      def broadcasting_redis
-        @broadcasting_redis ||= Redis.new(config.redis)
-      end
-
       private
         class Broadcaster
           attr_reader :server, :broadcasting
@@ -46,7 +41,7 @@ module ActionCable
 
           def broadcast(message)
             server.logger.info "[ActionCable] Broadcasting to #{broadcasting}: #{message}"
-            server.broadcasting_redis.publish broadcasting, ActiveSupport::JSON.encode(message)
+            server.redis.publish broadcasting, ActiveSupport::JSON.encode(message)
           end
         end
     end


### PR DESCRIPTION
This one took me a while to figure out why it was posting to the front end. It seems that calling Redis by itself doesn't call the callback set in streams and instead needs the EM connection.

1.) Switch to EM Redis Instance already established in `ActionCable::Server::Base`
2.) Put in a catch in case EM isn't started yet