### PR TITLE
Handle cases where logger is not a tagged logger.

### DIFF
--- a/lib/action_cable/connection/base.rb
+++ b/lib/action_cable/connection/base.rb
@@ -56,7 +56,7 @@ module ActionCable
       def initialize(server, env)
         @server, @env = server, env
 
-        @logger = new_tagged_logger || server.logger
+        @logger = new_tagged_logger
 
         @websocket      = ActionCable::Connection::WebSocket.new(env)
         @subscriptions  = ActionCable::Connection::Subscriptions.new(self)
@@ -194,10 +194,8 @@ module ActionCable
 
         # Tags are declared in the server but computed in the connection. This allows us per-connection tailored tags.
         def new_tagged_logger
-          if server.logger.respond_to?(:tagged)
-            TaggedLoggerProxy.new server.logger,
-              tags: server.config.log_tags.map { |tag| tag.respond_to?(:call) ? tag.call(request) : tag.to_s.camelize }
-          end
+          TaggedLoggerProxy.new server.logger,
+            tags: server.config.log_tags.map { |tag| tag.respond_to?(:call) ? tag.call(request) : tag.to_s.camelize }
         end
 
         def started_request_message

--- a/lib/action_cable/connection/tagged_logger_proxy.rb
+++ b/lib/action_cable/connection/tagged_logger_proxy.rb
@@ -16,6 +16,15 @@ module ActionCable
         @tags = @tags.uniq
       end
 
+      def tag(logger)
+        if logger.respond_to?(:tagged)
+          current_tags = tags - logger.formatter.current_tags
+          logger.tagged(*current_tags) { yield }
+        else
+          yield
+        end
+      end
+
       %i( debug info warn error fatal unknown ).each do |severity|
         define_method(severity) do |message|
           log severity, message
@@ -24,8 +33,7 @@ module ActionCable
 
       protected
         def log(type, message)
-          current_tags = tags - @logger.formatter.current_tags
-          @logger.tagged(*current_tags) { @logger.send type, message }
+          tag(@logger) { @logger.send type, message }
         end
     end
   end

--- a/lib/action_cable/server/worker/active_record_connection_management.rb
+++ b/lib/action_cable/server/worker/active_record_connection_management.rb
@@ -12,7 +12,7 @@ module ActionCable
         end
 
         def with_database_connections
-          ActiveRecord::Base.logger.tagged(*connection.logger.tags) { yield }
+          connection.logger.tag(ActiveRecord::Base.logger) { yield }
         ensure
           ActiveRecord::Base.clear_active_connections!
         end


### PR DESCRIPTION
Previously, a TaggedLoggerProxy was only created if the logger responded to
:tagged, but was still used as if it was a TaggedLoggerProxy elsewhere in the
code, causing undefined method  errors.

This moved the check for tagging abilities inside the TaggedLoggerProxy so the
code can always tread the logger like a tagged logger, and if it is not a
tagged logger the tags will just be ignored. This prevents needing to check
if the logger is tagged every time we use it.

Fixes #121 