### PR TITLE
Allow regexp for a allowed_request_origins array

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,10 +304,10 @@ ActionCable.server.config.redis_path = Rails.root('somewhere/else/cable.yml')
 
 ### Allowed Request Origins
 
-Action Cable will only accepting requests from specified origins, which are passed to the server config as an array:
+Action Cable will only accept requests from specified origins, which are passed to the server config as an array. The origins can be instances of strings or regular expressions, against which a check for match will be performed.
 
 ```ruby
-ActionCable.server.config.allowed_request_origins = %w( http://rubyonrails.com )
+ActionCable.server.config.allowed_request_origins = ['http://rubyonrails.com', /http:\/\/ruby.*/]
 ```
 
 To disable and allow requests from any origin:

--- a/lib/action_cable/connection/base.rb
+++ b/lib/action_cable/connection/base.rb
@@ -180,11 +180,6 @@ module ActionCable
           end
         end
 
-        def allowed_origins_match? origin
-          allowed_origins = Array(server.config.allowed_request_origins)
-          allowed_origins.any? { |allowed_origin| allowed_origin.is_a?(Regexp) ? allowed_origin =~ origin : allowed_origin == origin }
-        end
-
         def respond_to_successful_request
           websocket.rack_response
         end

--- a/lib/action_cable/connection/base.rb
+++ b/lib/action_cable/connection/base.rb
@@ -172,12 +172,17 @@ module ActionCable
         def allow_request_origin?
           return true if server.config.disable_request_forgery_protection
 
-          if Array(server.config.allowed_request_origins).include? env['HTTP_ORIGIN']
+          if Array(server.config.allowed_request_origins).any? { |allowed_origin|  allowed_origin === env['HTTP_ORIGIN'] }
             true
           else
             logger.error("Request origin not allowed: #{env['HTTP_ORIGIN']}")
             false
           end
+        end
+
+        def allowed_origins_match? origin
+          allowed_origins = Array(server.config.allowed_request_origins)
+          allowed_origins.any? { |allowed_origin| allowed_origin.is_a?(Regexp) ? allowed_origin =~ origin : allowed_origin == origin }
         end
 
         def respond_to_successful_request

--- a/test/connection/cross_site_forgery_test.rb
+++ b/test/connection/cross_site_forgery_test.rb
@@ -40,6 +40,20 @@ class ActionCable::Connection::CrossSiteForgeryTest < ActionCable::TestCase
     assert_origin_not_allowed 'http://hax.com'
   end
 
+  test "explicitly specified a single regexp allowed origin" do
+    @server.config.allowed_request_origins = /.*ha.*/
+    assert_origin_not_allowed 'http://rubyonrails.com'
+    assert_origin_allowed 'http://hax.com'
+  end
+
+  test "explicitly specified multiple regexp allowed origins" do
+    @server.config.allowed_request_origins = [/http:\/\/ruby.*/, /.*rai.s.*com/, 'string' ]
+    assert_origin_allowed 'http://rubyonrails.com'
+    assert_origin_allowed 'http://www.rubyonrails.com'
+    assert_origin_not_allowed 'http://hax.com'
+    assert_origin_not_allowed 'http://rails.co.uk'
+  end
+
   private
     def assert_origin_allowed(origin)
       response = connect_with_origin origin


### PR DESCRIPTION
Adding the feature of additional regexp check for `allowed_origin_requests`instead of only strict equal comparation.

Fixes #130 