### PR TITLE
Update README find_verified_user example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ module ApplicationCable
 
     protected
       def find_verified_user
-        if current_user = User.find(cookies.signed[:user_id])
+        if current_user = User.find_by(id: cookies.signed[:user_id])
           current_user
         else
           reject_unauthorized_connection


### PR DESCRIPTION
A minor update to README.md `find_verified_user` example, `find` raises exception, so use `find_by`.