### PR TITLE
Introduce cable Rack Middleware

### DIFF
--- a/lib/action_cable.rb
+++ b/lib/action_cable.rb
@@ -25,6 +25,7 @@ module ActionCable
     autoload :Connection
     autoload :Channel
     autoload :RemoteConnections
+    autoload :Middleware
   end
 end
 

--- a/lib/action_cable/middleware.rb
+++ b/lib/action_cable/middleware.rb
@@ -1,0 +1,16 @@
+require 'faye/websocket'
+module ActionCable
+  class Middleware
+    def initialize(app, options={})
+      @app = app
+    end
+
+    def call(env)
+      if Faye::WebSocket.websocket?(env)
+        ActionCable.server.call(env)
+      else
+        @app.call(env)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows a single rails app to support websocket requests

I added the following to the bottom of my `config/initializers/{development,production}.rb`:

```ruby
config.middleware.use "ActionCable::Middleware"
```

/cc @jmbejar and @SophieDeBenedetto Thanks for sharing this information. This ok to put into `actioncable`?